### PR TITLE
Add metadata for Anaxa, Castorice, RuanMei, and Dashboard pages

### DIFF
--- a/visual_dashboard/src/app/constants.ts
+++ b/visual_dashboard/src/app/constants.ts
@@ -1,0 +1,4 @@
+export const SITE_TITLE =
+  "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis";
+export const SITE_DESCRIPTION =
+  "Analyze the value proposition of different Eidolon levels and signature lightcone for characters in Honkai: Star Rail";

--- a/visual_dashboard/src/app/dashboard/anaxa/page.tsx
+++ b/visual_dashboard/src/app/dashboard/anaxa/page.tsx
@@ -1,3 +1,15 @@
+import { SITE_TITLE, SITE_DESCRIPTION } from "@/app/layout";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
+
 export default function AnaxaPage() {
   return (
     <div className="flex flex-col items-center p-6 w-full h-full min-h-screen">

--- a/visual_dashboard/src/app/dashboard/anaxa/page.tsx
+++ b/visual_dashboard/src/app/dashboard/anaxa/page.tsx
@@ -1,4 +1,4 @@
-import { SITE_TITLE, SITE_DESCRIPTION } from "@/app/layout";
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/constants";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/visual_dashboard/src/app/dashboard/castorice/page.tsx
+++ b/visual_dashboard/src/app/dashboard/castorice/page.tsx
@@ -1,3 +1,16 @@
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/layout";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
+
+
 export default function CastoricePage() {
   return (
     <div className="flex flex-col items-center p-6 w-full h-full min-h-screen">

--- a/visual_dashboard/src/app/dashboard/castorice/page.tsx
+++ b/visual_dashboard/src/app/dashboard/castorice/page.tsx
@@ -10,7 +10,6 @@ export const metadata: Metadata = {
   },
 };
 
-
 export default function CastoricePage() {
   return (
     <div className="flex flex-col items-center p-6 w-full h-full min-h-screen">

--- a/visual_dashboard/src/app/dashboard/castorice/page.tsx
+++ b/visual_dashboard/src/app/dashboard/castorice/page.tsx
@@ -1,4 +1,4 @@
-import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/layout";
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/constants";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/visual_dashboard/src/app/dashboard/page.tsx
+++ b/visual_dashboard/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { SITE_DESCRIPTION, SITE_TITLE } from "../layout";
+import { SITE_DESCRIPTION, SITE_TITLE } from "../constants";
 
 export const metadata: Metadata = {
   title: SITE_TITLE,

--- a/visual_dashboard/src/app/dashboard/page.tsx
+++ b/visual_dashboard/src/app/dashboard/page.tsx
@@ -12,7 +12,6 @@ export const metadata: Metadata = {
   },
 };
 
-
 export default function DashboardPage() {
   return (
     <main className="max-w-2xl mx-auto p-6">

--- a/visual_dashboard/src/app/dashboard/page.tsx
+++ b/visual_dashboard/src/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { Metadata } from "next";
 import Link from "next/link";
 import { SITE_DESCRIPTION, SITE_TITLE } from "../layout";

--- a/visual_dashboard/src/app/dashboard/page.tsx
+++ b/visual_dashboard/src/app/dashboard/page.tsx
@@ -1,5 +1,17 @@
 "use client";
+import { Metadata } from "next";
 import Link from "next/link";
+import { SITE_DESCRIPTION, SITE_TITLE } from "../layout";
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
+
 
 export default function DashboardPage() {
   return (

--- a/visual_dashboard/src/app/dashboard/ruanmei/page.tsx
+++ b/visual_dashboard/src/app/dashboard/ruanmei/page.tsx
@@ -1,4 +1,4 @@
-import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/layout";
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/constants";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/visual_dashboard/src/app/dashboard/ruanmei/page.tsx
+++ b/visual_dashboard/src/app/dashboard/ruanmei/page.tsx
@@ -1,3 +1,15 @@
+import { SITE_DESCRIPTION, SITE_TITLE } from "@/app/layout";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
+
 export default function RuanMeiPage() {
   return (
     <div className="flex flex-col items-center p-6 w-full h-full min-h-screen">

--- a/visual_dashboard/src/app/layout.tsx
+++ b/visual_dashboard/src/app/layout.tsx
@@ -12,10 +12,17 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+export const SITE_TITLE = "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis";
+export const SITE_DESCRIPTION =
+  "Analyze the value proposition of different Eidolon levels and signature lightcone for characters in Honkai: Star Rail";
+
 export const metadata: Metadata = {
-  title: "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis",
-  description:
-    "Analyze the value proposition of different Eidolon levels and signature lightcone for characters in Honkai: Star Rail",
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/visual_dashboard/src/app/layout.tsx
+++ b/visual_dashboard/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { SITE_TITLE, SITE_DESCRIPTION } from "./constants";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -11,11 +12,6 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
-
-export const SITE_TITLE =
-  "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis";
-export const SITE_DESCRIPTION =
-  "Analyze the value proposition of different Eidolon levels and signature lightcone for characters in Honkai: Star Rail";
 
 export const metadata: Metadata = {
   title: SITE_TITLE,

--- a/visual_dashboard/src/app/layout.tsx
+++ b/visual_dashboard/src/app/layout.tsx
@@ -12,7 +12,8 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const SITE_TITLE = "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis";
+export const SITE_TITLE =
+  "Honkai: Star Rail Eidolon and Signature Lightcone Value Analysis";
 export const SITE_DESCRIPTION =
   "Analyze the value proposition of different Eidolon levels and signature lightcone for characters in Honkai: Star Rail";
 

--- a/visual_dashboard/src/app/page.tsx
+++ b/visual_dashboard/src/app/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { SITE_TITLE, SITE_DESCRIPTION } from "./layout";
 
-
 export const metadata: Metadata = {
   title: SITE_TITLE,
   description: SITE_DESCRIPTION,

--- a/visual_dashboard/src/app/page.tsx
+++ b/visual_dashboard/src/app/page.tsx
@@ -1,4 +1,16 @@
+import { Metadata } from "next";
 import Link from "next/link";
+import { SITE_TITLE, SITE_DESCRIPTION } from "./layout";
+
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
 
 export default function Home() {
   return (

--- a/visual_dashboard/src/app/page.tsx
+++ b/visual_dashboard/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { SITE_TITLE, SITE_DESCRIPTION } from "./layout";
+import { SITE_TITLE, SITE_DESCRIPTION } from "./constants";
 
 export const metadata: Metadata = {
   title: SITE_TITLE,


### PR DESCRIPTION
Introduce metadata for several pages to enhance SEO and social sharing capabilities. Clean up code by removing unnecessary blank lines in page and layout files.